### PR TITLE
Use `10up/wpcs-action@v1.7.0`

### DIFF
--- a/workflows/cpcs.yml
+++ b/workflows/cpcs.yml
@@ -21,7 +21,7 @@ jobs:
             sed -i '/MY_DOMAIN/ s//CHANGE-THIS-TO-YOUR-TEXT-DOMAIN/' phpcs.xml
             mv phpcs.xml phpcs.xml.dist
         - name: CPCS checks
-          uses: 10up/wpcs-action@stable
+          uses: 10up/wpcs-action@v1.7.0
           with:
             use_local_config: 'true'
             enable_warnings: 'true'


### PR DESCRIPTION
10up/wpcs-action released version 2.0.0.

The action is failing. Seems that a proper `composer.json` must be in place for the action to run.
This can be achieved adding something like
```
        - name: Setup composer.json
          run: |
              composer -n --name=${{ github.repository }} init
```

Anyway, even if this bug is solved, version 2.0.0 upgrades WordPress Coding Standards to 3.1.0, so [ClassicPress Coding Standards](https://github.com/ClassicPress/ClassicPress-Coding-Standards/blob/main/phpcs.xml) have to be also updated.

**So my proposal is to use wpcs-action at v1.7.0 as it's working properly.**

Closes #2.
