### PR TITLE
Bump actions versions to fix Node warning

### DIFF
--- a/workflows/add-zip-to-release.yml
+++ b/workflows/add-zip-to-release.yml
@@ -18,7 +18,7 @@ jobs:
           git archive -o ${{ github.event.repository.name }}-${{ github.ref_name }}.zip --prefix ${{ github.event.repository.name }}/ HEAD 
           ls
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
             name: ${{ github.event.repository.name }}-${{ github.ref_name }}
             path: ${{ github.event.repository.name }}-${{ github.ref_name }}.zip

--- a/workflows/add-zip-to-release.yml
+++ b/workflows/add-zip-to-release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: setup git config
         run: |
           git config user.name "GitHub Actions Bot"
@@ -18,7 +18,7 @@ jobs:
           git archive -o ${{ github.event.repository.name }}-${{ github.ref_name }}.zip --prefix ${{ github.event.repository.name }}/ HEAD 
           ls
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
             name: ${{ github.event.repository.name }}-${{ github.ref_name }}
             path: ${{ github.event.repository.name }}-${{ github.ref_name }}.zip

--- a/workflows/add-zip-to-release.yml
+++ b/workflows/add-zip-to-release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: setup git config
         run: |
           git config user.name "GitHub Actions Bot"

--- a/workflows/cpcs.yml
+++ b/workflows/cpcs.yml
@@ -11,7 +11,7 @@ jobs:
       name: CPCS
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: CPCS get rules
           run: |
             wget -O phpcs.xml https://raw.githubusercontent.com/ClassicPress/ClassicPress-Coding-Standards/main/phpcs.xml

--- a/workflows/cpcs.yml
+++ b/workflows/cpcs.yml
@@ -11,7 +11,7 @@ jobs:
       name: CPCS
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@v7
         - name: CPCS get rules
           run: |
             wget -O phpcs.xml https://raw.githubusercontent.com/ClassicPress/ClassicPress-Coding-Standards/main/phpcs.xml


### PR DESCRIPTION
- ~Use `actions/checkout@v6`~
- ~Use `actions/upload-artifact@v6`~
- Use `actions/checkout@v7`
- Use `actions/upload-artifact@v7`

This fix the following warning:
`Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected.`

Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.
